### PR TITLE
WIP: Update label shortcodes

### DIFF
--- a/data/856/323/43/85632343.geojson
+++ b/data/856/323/43/85632343.geojson
@@ -15,6 +15,9 @@
     "itu:country_code":[
         "376"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AD"
+    ],
     "lbl:latitude":42.547076,
     "lbl:longitude":1.576286,
     "mps:latitude":42.547076,
@@ -1130,16 +1133,13 @@
         }
     ],
     "wof:id":85632343,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251394,
+    "wof:lastmodified":1565634328,
     "wof:name":"Andorra",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/679/23/85667923.geojson
+++ b/data/856/679/23/85667923.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "parish"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AN"
+    ],
     "lbl:latitude":42.511248,
     "lbl:longitude":1.510242,
     "mps:latitude":42.511248,
@@ -186,16 +189,13 @@
         }
     ],
     "wof:id":85667923,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251403,
+    "wof:lastmodified":1565634328,
     "wof:name":"Andorra la Vella",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/25/85667925.geojson
+++ b/data/856/679/25/85667925.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "parish"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MA"
+    ],
     "lbl:latitude":42.553947,
     "lbl:longitude":1.462699,
     "mps:latitude":42.553947,
@@ -347,16 +350,13 @@
         }
     ],
     "wof:id":85667925,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251404,
+    "wof:lastmodified":1565634328,
     "wof:name":"La Massana",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/29/85667929.geojson
+++ b/data/856/679/29/85667929.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "parish"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "OR"
+    ],
     "lbl:latitude":42.607119,
     "lbl:longitude":1.527873,
     "mps:latitude":42.607119,
@@ -344,16 +347,13 @@
         }
     ],
     "wof:id":85667929,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251397,
+    "wof:lastmodified":1565634328,
     "wof:name":"Ordino",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/33/85667933.geojson
+++ b/data/856/679/33/85667933.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "parish"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "CA"
+    ],
     "lbl:latitude":42.592356,
     "lbl:longitude":1.656471,
     "mps:latitude":42.592356,
@@ -350,16 +353,13 @@
         }
     ],
     "wof:id":85667933,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251396,
+    "wof:lastmodified":1565634328,
     "wof:name":"Canillo",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/39/85667939.geojson
+++ b/data/856/679/39/85667939.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "parish"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "EN"
+    ],
     "lbl:latitude":42.540798,
     "lbl:longitude":1.659738,
     "mps:latitude":42.540798,
@@ -353,16 +356,13 @@
         }
     ],
     "wof:id":85667939,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251399,
+    "wof:lastmodified":1565634328,
     "wof:name":"Encamp",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/41/85667941.geojson
+++ b/data/856/679/41/85667941.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "parish"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "EE"
+    ],
     "lbl:latitude":42.490119,
     "lbl:longitude":1.607302,
     "mps:latitude":42.490119,
@@ -335,16 +338,13 @@
         }
     ],
     "wof:id":85667941,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251400,
+    "wof:lastmodified":1565634328,
     "wof:name":"Escaldes-Engordany",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/45/85667945.geojson
+++ b/data/856/679/45/85667945.geojson
@@ -17,6 +17,9 @@
     "label:eng_x_preferred_placetype":[
         "parish"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "JL"
+    ],
     "lbl:latitude":42.466032,
     "lbl:longitude":1.473523,
     "mps:latitude":42.466032,
@@ -344,16 +347,13 @@
         }
     ],
     "wof:id":85667945,
-    "wof:lang":[
-        "unk"
-    ],
     "wof:lang_x_official":[
         "cat"
     ],
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1563251398,
+    "wof:lastmodified":1565634328,
     "wof:name":"Sant Juli\u00e0 de L\u00f2ria",
     "wof:parent_id":85632343,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1689.

- Adds a `label:eng_x_preferred_shortcode` property to any country, macroregion, region, or dependency record
- Removes any `wof:lang` property if `wof:lang_x_official` and `wof:lang_x_spoken` properties are present

Will not require PIP work, property edits only.