### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/851/341/101851341.geojson
+++ b/data/101/851/341/101851341.geojson
@@ -119,6 +119,10 @@
         "wk:page":"El Tarter"
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e655f652c6fd8a9e43dbc8bb2682a2e2",
     "wof:hierarchy":[
         {
@@ -132,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"el Tarter",
     "wof:parent_id":85667933,
     "wof:placetype":"locality",

--- a/data/101/851/343/101851343.geojson
+++ b/data/101/851/343/101851343.geojson
@@ -150,6 +150,10 @@
         "qs_pg:id":489804
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b317d97c4bc49a1df54deace3d0c854",
     "wof:hierarchy":[
         {
@@ -163,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"Sant Juli\u00e0 de L\u00f2ria",
     "wof:parent_id":85667945,
     "wof:placetype":"locality",

--- a/data/101/851/345/101851345.geojson
+++ b/data/101/851/345/101851345.geojson
@@ -123,6 +123,9 @@
         "wd:id":"Q3885480"
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e67005b5f15e80f16dd57b7824934da9",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"Ordino",
     "wof:parent_id":85667925,
     "wof:placetype":"locality",

--- a/data/101/851/347/101851347.geojson
+++ b/data/101/851/347/101851347.geojson
@@ -203,6 +203,10 @@
         "qs_pg:id":489807
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"64f636abe86fe8a94f0830fce2333d9b",
     "wof:hierarchy":[
         {
@@ -216,7 +220,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"Canillo",
     "wof:parent_id":85667933,
     "wof:placetype":"locality",

--- a/data/101/851/349/101851349.geojson
+++ b/data/101/851/349/101851349.geojson
@@ -86,6 +86,10 @@
         "wd:id":"Q3820973"
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"13f507124631a9361925bdae3897d82c",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
         }
     ],
     "wof:id":101851349,
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"La Massana",
     "wof:parent_id":85667925,
     "wof:placetype":"locality",

--- a/data/101/851/351/101851351.geojson
+++ b/data/101/851/351/101851351.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q3820973"
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba5347c5f493cda472123bc74197485c",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101851351,
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"La Massana",
     "wof:parent_id":85667945,
     "wof:placetype":"locality",

--- a/data/101/877/133/101877133.geojson
+++ b/data/101/877/133/101877133.geojson
@@ -60,6 +60,9 @@
         "qs_pg:id":471629
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"819b67bfdb1cdeeee78cdb6789dbee19",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101877133,
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"Pas de la Casa",
     "wof:parent_id":85667939,
     "wof:placetype":"locality",

--- a/data/101/877/135/101877135.geojson
+++ b/data/101/877/135/101877135.geojson
@@ -589,6 +589,9 @@
         "wk:page":"Andorra la Vella"
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eaf2346050dfa04c2c2c587b47d84325",
     "wof:hierarchy":[
         {
@@ -602,7 +605,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1582311928,
     "wof:name":"Andorra la Vella",
     "wof:parent_id":85667923,
     "wof:placetype":"locality",

--- a/data/101/877/137/101877137.geojson
+++ b/data/101/877/137/101877137.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Les Escaldes"
     },
     "wof:country":"AD",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b6cca48aad87e632ec882dcdbcbdaa81",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581572,
+    "wof:lastmodified":1582311928,
     "wof:name":"Escaldes-Engordany",
     "wof:parent_id":85667941,
     "wof:placetype":"locality",

--- a/data/856/323/43/85632343.geojson
+++ b/data/856/323/43/85632343.geojson
@@ -1121,6 +1121,9 @@
     },
     "wof:country":"AD",
     "wof:country_alpha3":"AND",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"e96ae0447aefca2dd577d564fa0ea3fa",
     "wof:hierarchy":[
         {
@@ -1135,7 +1138,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1582311927,
     "wof:name":"Andorra",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.