### PR TITLE
ad concordances, placetype local, and more

### DIFF
--- a/data/856/323/43/85632343.geojson
+++ b/data/856/323/43/85632343.geojson
@@ -1257,6 +1257,7 @@
         "hasc:id":"AD",
         "icao:code":"C3",
         "ioc:id":"AND",
+        "iso:code":"AD",
         "itu:id":"AND",
         "loc:id":"n80113598",
         "m49:code":"020",
@@ -1270,6 +1271,7 @@
         "wd:id":"Q228",
         "wk:page":"Andorra"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AD",
     "wof:country_alpha3":"AND",
     "wof:geom_alt":[
@@ -1289,7 +1291,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1694639494,
+    "wof:lastmodified":1695881148,
     "wof:name":"Andorra",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/679/23/85667923.geojson
+++ b/data/856/679/23/85667923.geojson
@@ -238,16 +238,18 @@
         "gn:id":3041566,
         "gp:id":20070553,
         "hasc:id":"AD.AN",
+        "iso:code":"AD-07",
         "iso:id":"AD-07",
         "qs_pg:id":1115276,
         "unlc:id":"AD-07",
         "wd:id":"Q2522163"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         101877135
     ],
     "wof:country":"AD",
-    "wof:geomhash":"fb0aaaced840a6006f6da18fe723366e",
+    "wof:geomhash":"8fc4ed1556b6bde9719ed0c5a3827c05",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -262,7 +264,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1690848448,
+    "wof:lastmodified":1695884762,
     "wof:name":"Andorra la Vella",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/25/85667925.geojson
+++ b/data/856/679/25/85667925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007947,
-    "geom:area_square_m":72382459.826689,
+    "geom:area_square_m":72382631.511493,
     "geom:bbox":"1.406456,42.504073,1.556351,42.602052",
     "geom:latitude":42.554071,
     "geom:longitude":1.474054,
@@ -342,14 +342,16 @@
         "gn:id":3040131,
         "gp:id":20070555,
         "hasc:id":"AD.MA",
+        "iso:code":"AD-04",
         "iso:id":"AD-04",
         "qs_pg:id":1102991,
         "unlc:id":"AD-04",
         "wd:id":"Q24276",
         "wk:page":"La Massana"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AD",
-    "wof:geomhash":"565e08e1adbf95f05d2e2e4393630bc1",
+    "wof:geomhash":"9c9ebde3e5add3666f523bf09f2b905a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -364,7 +366,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1690848448,
+    "wof:lastmodified":1695884762,
     "wof:name":"La Massana",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/29/85667929.geojson
+++ b/data/856/679/29/85667929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008388,
-    "geom:area_square_m":76332225.825411,
+    "geom:area_square_m":76332186.935767,
     "geom:bbox":"1.451415,42.562654,1.598739,42.649362",
     "geom:latitude":42.608978,
     "geom:longitude":1.52647,
@@ -341,14 +341,16 @@
         "gn:id":3039676,
         "gp:id":20070556,
         "hasc:id":"AD.OR",
+        "iso:code":"AD-05",
         "iso:id":"AD-05",
         "qs_pg:id":223897,
         "unlc:id":"AD-05",
         "wd:id":"Q24272",
         "wk:page":"Ordino"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AD",
-    "wof:geomhash":"cbf11ec909fef2c67bb57b8effc59122",
+    "wof:geomhash":"fb10de0968d1899509a1e392d37aaf09",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1690848447,
+    "wof:lastmodified":1695884762,
     "wof:name":"Ordino",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/33/85667933.geojson
+++ b/data/856/679/33/85667933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008136,
-    "geom:area_square_m":74076475.110681,
+    "geom:area_square_m":74076191.482611,
     "geom:bbox":"1.555607,42.53989,1.765091,42.621921",
     "geom:latitude":42.584522,
     "geom:longitude":1.658058,
@@ -347,14 +347,16 @@
         "gn:id":3041203,
         "gp:id":20070557,
         "hasc:id":"AD.CA",
+        "iso:code":"AD-02",
         "iso:id":"AD-02",
         "qs_pg:id":892927,
         "unlc:id":"AD-02",
         "wd:id":"Q24260",
         "wk:page":"Canillo"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AD",
-    "wof:geomhash":"83c9654b4b247c0b3fdd429c49e0a55b",
+    "wof:geomhash":"6ed08f08cd142f009b42265fb8d13c21",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -369,7 +371,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1690848446,
+    "wof:lastmodified":1695884323,
     "wof:name":"Canillo",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/39/85667939.geojson
+++ b/data/856/679/39/85667939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00783,
-    "geom:area_square_m":71340334.843947,
+    "geom:area_square_m":71340512.913385,
     "geom:bbox":"1.555607,42.490508,1.717091,42.574553",
     "geom:latitude":42.537281,
     "geom:longitude":1.645058,
@@ -350,14 +350,16 @@
         "gn:id":3040684,
         "gp:id":20070558,
         "hasc:id":"AD.EN",
+        "iso:code":"AD-03",
         "iso:id":"AD-03",
         "qs_pg:id":223899,
         "unlc:id":"AD-03",
         "wd:id":"Q24269",
         "wk:page":"Encamp"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AD",
-    "wof:geomhash":"866a6ac3c022ebd6f9ae78b3a7da2d89",
+    "wof:geomhash":"4d27087cbe486de8a96a2609aeee6d9e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -372,7 +374,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1690848447,
+    "wof:lastmodified":1695884323,
     "wof:name":"Encamp",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/41/85667941.geojson
+++ b/data/856/679/41/85667941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007252,
-    "geom:area_square_m":66118413.785504,
+    "geom:area_square_m":66118323.572242,
     "geom:bbox":"1.499089,42.453075,1.656984,42.538857",
     "geom:latitude":42.495963,
     "geom:longitude":1.588761,
@@ -344,14 +344,16 @@
         "gn:id":3338529,
         "gp:id":20070554,
         "hasc:id":"AD.EE",
+        "iso:code":"AD-08",
         "iso:id":"AD-08",
         "qs_pg:id":466367,
         "unlc:id":"AD-08",
         "wd:id":"Q24286",
         "wk:page":"Escaldes-Engordany"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AD",
-    "wof:geomhash":"49c1e58df1812f4d325d490ed35c66f8",
+    "wof:geomhash":"8ca606cf14e8b8ae2a248a684d5ccda7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1690848447,
+    "wof:lastmodified":1695884762,
     "wof:name":"Escaldes-Engordany",
     "wof:parent_id":85632343,
     "wof:placetype":"region",

--- a/data/856/679/45/85667945.geojson
+++ b/data/856/679/45/85667945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00842,
-    "geom:area_square_m":76801496.134797,
+    "geom:area_square_m":76801496.134796,
     "geom:bbox":"1.40759322065,42.4286774707,1.57494232972,42.5180350337",
     "geom:latitude":42.467892,
     "geom:longitude":1.488736,
@@ -329,14 +329,16 @@
         "gn:id":3039162,
         "gp:id":20070564,
         "hasc:id":"AD.JL",
+        "iso:code":"AD-06",
         "iso:id":"AD-06",
         "qs_pg:id":1102992,
         "unlc:id":"AD-06",
         "wd:id":"Q24282",
         "wk:page":"Sant Juli\u00e0 de L\u00f2ria"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AD",
-    "wof:geomhash":"99019ac9fa792443ccf664986e031de1",
+    "wof:geomhash":"0be4dac9e64df03dbee0c349a4c8ca2f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -351,7 +353,7 @@
     "wof:lang_x_spoken":[
         "cat"
     ],
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1695884323,
     "wof:name":"Sant Juli\u00e0 de L\u00f2ria",
     "wof:parent_id":85632343,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.